### PR TITLE
FOLIO-3045: Replace http by https in http://maven.indexdata.com/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <repository>
       <id>indexdata</id>
       <name>Index Data</name>
-      <url>http://maven.indexdata.com/</url>
+      <url>https://maven.indexdata.com/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Fix Machine-in-the-Middle (MITM) attack vulnerability when maven runs pom.xml, for details see https://issues.folio.org/browse/FOLIO-3044